### PR TITLE
nullcheck for $this->email

### DIFF
--- a/app/src/Database/Models/User.php
+++ b/app/src/Database/Models/User.php
@@ -157,7 +157,10 @@ class User extends Model implements UserInterface
      */
     public function getAvatarAttribute(): string
     {
-        $hash = md5(strtolower(trim($this->email)));
+        $hash = "";
+        if ($this->email !== null){
+            $hash = md5(strtolower(trim($this->email)));
+        }
 
         return 'https://www.gravatar.com/avatar/' . $hash . '?d=mm';
     }

--- a/app/src/Database/Models/User.php
+++ b/app/src/Database/Models/User.php
@@ -157,8 +157,8 @@ class User extends Model implements UserInterface
      */
     public function getAvatarAttribute(): string
     {
-        $hash = "";
-        if ($this->email !== null){
+        $hash = '';
+        if ($this->email !== null) {
             $hash = md5(strtolower(trim($this->email)));
         }
 

--- a/app/src/Database/Models/User.php
+++ b/app/src/Database/Models/User.php
@@ -157,10 +157,8 @@ class User extends Model implements UserInterface
      */
     public function getAvatarAttribute(): string
     {
-        $hash = '';
-        if ($this->email !== null) {
-            $hash = md5(strtolower(trim($this->email)));
-        }
+        $email = $this->email ?? '';
+        $hash = md5(strtolower(trim($email)));
 
         return 'https://www.gravatar.com/avatar/' . $hash . '?d=mm';
     }

--- a/app/tests/Database/Models/UserTest.php
+++ b/app/tests/Database/Models/UserTest.php
@@ -118,6 +118,19 @@ class UserTest extends AccountTestCase
     }
 
     /**
+     * @see https://github.com/userfrosting/sprinkle-account/pull/15
+     */
+    public function testUserAvatarForEmptyEmail(): void
+    {
+        /** @var User */
+        $user = new User();
+        $data = $user->toArray();
+
+        $this->assertArrayNotHasKey('email', $data);
+        $this->assertSame('https://www.gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?d=mm', $data['avatar']);
+    }
+
+    /**
      * Test user hard deletion.
      */
     public function testUserForceDelete(): void


### PR DESCRIPTION
Without the nullcheck, a permissions test against `!is_master(self.id)` results in the error `trim(): Argument #1 ($string) must be of type string, null given` here in `getAvatarAttribute()`.

With the nullcheck, there is no error and `userfrosting.log` gives
```txt
[2024-01-31T18:47:36.554796-05:00] auth.DEBUG: Evaluating access condition '!is_master(self.id)' with parameters: {
    "user": {
        "UserFrosting\\Sprinkle\\Account\\Database\\Models\\User": {
            "full_name": " ",
            "avatar": "https://www.gravatar.com/avatar/?d=mm"
        }
    },
    "self": {
[etc]
```

While `$this->email` appears elsewhere to be expected as type `string` rather than `?string`, the auth.DEBUG output demonstrates that it is somehow fed a blank `$user` from somewhere.

This PR is a bandaid fix. Searching for the source of the blank `$user` and resolving that would be a better fix.
